### PR TITLE
Update fee

### DIFF
--- a/contracts/DeRafl.sol
+++ b/contracts/DeRafl.sol
@@ -45,12 +45,10 @@ contract DeRafl is VRFConsumerBaseV2, Ownable, ERC1155Holder {
     uint256 internal constant MIN_ETH = 0.1 ether;
     /// @dev Maximum royalty fee percentage (10%)
     uint256 internal constant FEE_DENOMINATOR = 10000;
-    /// @dev Maximum royalty fee percentage (10%)
-    uint64 internal constant MAX_ROYALTY_FEE_PERCENTAGE = 1000;
-    /// @dev DeRafl protocol fee (5%)
-    uint256 internal constant DERAFL_FEE_PERCENTAGE = 500;
-    /// @dev DeRafl Chainlink Fee
-    uint256 internal constant DERAFL_CHAINLINK_FEE = 0.005 ether;
+    /// @dev Maximum royalty fee percentage (5%)
+    uint64 internal constant MAX_ROYALTY_FEE_PERCENTAGE = 500;
+    /// @dev DeRafl protocol fee (0.55%)
+    uint256 internal constant DERAFL_FEE_PERCENTAGE = 50;
     /// @dev Price per ticket
     uint96 internal constant TICKET_PRICE = 0.001 ether;
 
@@ -351,7 +349,7 @@ contract DeRafl is VRFConsumerBaseV2, Ownable, ERC1155Holder {
 
         // allocate and send the Eth
         uint256 ethRaised = raffle.ticketsSold * TICKET_PRICE;
-        uint256 protocolEth = ((ethRaised * DERAFL_FEE_PERCENTAGE) / FEE_DENOMINATOR) + DERAFL_CHAINLINK_FEE;
+        uint256 protocolEth = ethRaised * DERAFL_FEE_PERCENTAGE / FEE_DENOMINATOR;
         uint256 royaltyEth = raffle.royaltyPercentage == 0
             ? 0
             : (ethRaised * raffle.royaltyPercentage) / FEE_DENOMINATOR;

--- a/contracts/DeRafl.sol
+++ b/contracts/DeRafl.sol
@@ -47,7 +47,7 @@ contract DeRafl is VRFConsumerBaseV2, Ownable, ERC1155Holder {
     uint256 internal constant FEE_DENOMINATOR = 10000;
     /// @dev Maximum royalty fee percentage (5%)
     uint64 internal constant MAX_ROYALTY_FEE_PERCENTAGE = 500;
-    /// @dev DeRafl protocol fee (0.55%)
+    /// @dev DeRafl protocol fee (0.5%)
     uint256 internal constant DERAFL_FEE_PERCENTAGE = 50;
     /// @dev Price per ticket
     uint96 internal constant TICKET_PRICE = 0.001 ether;

--- a/test/derafl.test.ts
+++ b/test/derafl.test.ts
@@ -244,7 +244,7 @@ describe("DeRafl", function () {
 
         const feeCollectorBalanceAfter = await ethers.provider.getBalance(FEE_COLLECTOR)
         const ethRaised = BigNumber.from('10000').mul(parseEther('0.001'))
-        const deraflFee = ethRaised.mul('5').div('100').add(parseEther('0.005'))
+        const deraflFee = ethRaised.mul('5').div('1000')
         const expectedBalance = feeCollectorBalanceBefore.add(deraflFee)
         expect(feeCollectorBalanceAfter).to.equal(expectedBalance)
 
@@ -387,7 +387,7 @@ describe("DeRafl", function () {
         const nftWithRoyalties = await MockErc2981.deploy("test", "TEST", royaltyFeeReceiver.address)
         const royalties = await derafl.getRoyaltyInfo(nftWithRoyalties.address, '1')
         expect(royalties.feeReceiver).to.equal(royaltyFeeReceiver.address)
-        expect(royalties.royaltyFee).to.equal('1000')
+        expect(royalties.royaltyFee).to.equal('500')
       })
 
       it('Shows correct royalties for Looks rare registry', async function () {


### PR DESCRIPTION
This pr reduces the max royalty collected for a collection to 5%, it removes the explicit chainlink fee, and reduces the protocol fee to 0.5%. Tests were adjusted to account for the fee changes